### PR TITLE
Adding Jest Test for stdout and console.log usage in CLI commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3488,6 +3488,12 @@
         "@types/node": "*"
       }
     },
+    "jest-mock-process": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jest-mock-process/-/jest-mock-process-1.4.0.tgz",
+      "integrity": "sha512-3LM1TyEaRKRjh/x9rZPmuy28r7q8cgNkHYcrPWtxXT3ZzPPS+bKNs2ysb8BJPVB41X5yM1sMtatvE5z2XJ0S/w==",
+      "dev": true
+    },
     "jest-pnp-resolver": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-config-prettier": "^7.1.0",
     "eslint-plugin-prettier": "^3.3.1",
     "jest": "^26.6.3",
+    "jest-mock-process": "^1.4.0",
     "pkg": "^5.3.0",
     "prettier": "^2.2.1",
     "ts-jest": "^26.4.4",

--- a/src/bin/typescript-demo-lib.ts
+++ b/src/bin/typescript-demo-lib.ts
@@ -2,13 +2,28 @@
 
 import process from 'process';
 import Library from '../lib/Library';
+import NumPair from '../lib/NumPair';
 import { v4 as uuidv4 } from 'uuid';
 
 function main(argv = process.argv): number {
-  console.log(argv.slice(2));
+  // Print out command-line arguments
+  const argArray = argv.slice(2);
+  const args = argArray.toString();
+  process.stdout.write('[' + args + ']\n');
+
+  // Create a new Library with the value someParam = 'new library'
+  // And print it out
   const l = new Library('new library');
-  console.log(l.someParam);
-  console.log(uuidv4());
+  process.stdout.write(l.someParam + '\n');
+
+  // Generate and print a uuid (universally unique identifier)
+  process.stdout.write(uuidv4() + '\n');
+
+  // Add the first two command-line args and print the result
+  const nums = new NumPair(parseInt(argv[2]), parseInt(argv[3]));
+  const sum = nums.num1 + nums.num2;
+  process.stdout.write(nums.num1 + ' + ' + nums.num2 + ' = ' + sum + '\n');
+
   process.exitCode = 0;
   return process.exitCode;
 }

--- a/src/lib/NumPair.ts
+++ b/src/lib/NumPair.ts
@@ -1,0 +1,11 @@
+class NumPair {
+  num1: number;
+  num2: number;
+
+  constructor(firstNum = 0, secondNum = 0) {
+    this.num1 = firstNum;
+    this.num2 = secondNum;
+  }
+}
+
+export default NumPair;

--- a/tests/bin/typescript-demo-lib.test.ts
+++ b/tests/bin/typescript-demo-lib.test.ts
@@ -1,9 +1,64 @@
+import { mockProcessStdout } from 'jest-mock-process';
 import main from '@/bin/typescript-demo-lib';
+
+const uuidRegex = new RegExp(
+  '^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}',
+);
 
 describe('main', () => {
   test('main takes synthetic parameters', () => {
     // jest can also "spy on" the console object
     // and then you can test on stdout
     expect(main(['1'])).toEqual(0);
+  });
+  test('no input', () => {
+    const mockLog = mockProcessStdout();
+    main(['thing', 'thing']);
+    expect(mockLog).toHaveBeenCalledTimes(4);
+    expect(mockLog.mock.calls[0][0]).toBe('[]\n');
+    expect(mockLog.mock.calls[1][0]).toBe('new library\n');
+    expect(mockLog.mock.calls[2][0]).toMatch(uuidRegex);
+    expect(mockLog.mock.calls[3][0]).toBe('NaN + NaN = NaN\n');
+    mockLog.mockRestore();
+  });
+  test('adds 0 + 0', () => {
+    const mockLog = mockProcessStdout();
+    main(['thing', 'thing', '0', '0']);
+    expect(mockLog).toHaveBeenCalledTimes(4);
+    expect(mockLog.mock.calls[0][0]).toBe('[0,0]\n');
+    expect(mockLog.mock.calls[1][0]).toBe('new library\n');
+    expect(mockLog.mock.calls[2][0]).toMatch(uuidRegex);
+    expect(mockLog.mock.calls[3][0]).toBe('0 + 0 = 0\n');
+    mockLog.mockRestore();
+  });
+  test('adds 0 + 1', () => {
+    const mockLog = mockProcessStdout();
+    main(['thing', 'thing', '0', '1']);
+    expect(mockLog).toHaveBeenCalledTimes(4);
+    expect(mockLog.mock.calls[0][0]).toBe('[0,1]\n');
+    expect(mockLog.mock.calls[1][0]).toBe('new library\n');
+    expect(mockLog.mock.calls[2][0]).toMatch(uuidRegex);
+    expect(mockLog.mock.calls[3][0]).toBe('0 + 1 = 1\n');
+    mockLog.mockRestore();
+  });
+  test('adds 1 + 0', () => {
+    const mockLog = mockProcessStdout();
+    main(['thing', 'thing', '1', '0']);
+    expect(mockLog).toHaveBeenCalledTimes(4);
+    expect(mockLog.mock.calls[0][0]).toBe('[1,0]\n');
+    expect(mockLog.mock.calls[1][0]).toBe('new library\n');
+    expect(mockLog.mock.calls[2][0]).toMatch(uuidRegex);
+    expect(mockLog.mock.calls[3][0]).toBe('1 + 0 = 1\n');
+    mockLog.mockRestore();
+  });
+  test('adds 7657 + 238947', () => {
+    const mockLog = mockProcessStdout();
+    main(['thing', 'thing', '7657', '238947']);
+    expect(mockLog).toHaveBeenCalledTimes(4);
+    expect(mockLog.mock.calls[0][0]).toBe('[7657,238947]\n');
+    expect(mockLog.mock.calls[1][0]).toBe('new library\n');
+    expect(mockLog.mock.calls[2][0]).toMatch(uuidRegex);
+    expect(mockLog.mock.calls[3][0]).toBe('7657 + 238947 = 246604\n');
+    mockLog.mockRestore();
   });
 });


### PR DESCRIPTION
Created a new function, demo-addition, that takes two numbers from the command line and adds them, then prints the result using console.log. This function utilises the NumPair class from a library called NumPair which stores two numbers. Tests were then created for this function using jest-test-process.

Once the function and tests were working for the console.log implementation the function and tests were then modified to use stdout instead.