### PR TITLE
Added note about VSCode and path aliases in tests [ci skip], fixes #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,24 @@ Due to https://github.com/microsoft/TypeScript/issues/10866, you cannot use path
 
 However we have left the path alias configuration in `tsconfig.json`, `jest.config.js` and in the tests we are making use of the `@` alias.
 
+#### VSCode Path Aliases
+
+VSCode cannot follow path aliases in our tests due to
+https://github.com/microsoft/vscode/issues/94474.
+
+To resolve this, add `./tests/**/*` into the `tsconfig` `include` section:
+
+```json
+  "include": [
+    "./src/**/*",
+    "./tests/**/*'
+  ]
+```
+
+This will however make `tsc` build the `tests` into the `dist` output.
+
+**Therefore this fix should only be done in your own workspace, do not commit or push this change up.**
+
 ### Docs Generation
 
 ```sh


### PR DESCRIPTION
### Description

Adds note in README.md explaining how to resolve path aliases for tests in vscode.

### Issues Fixed

* Fixes #18 

### Tasks
<!-- List all tasks to be done by this PR. -->
1. [x] Write README.md section

### Final checklist

* [ ] Domain specific tests with `npm test -- tests/DOMAIN`
* [ ] Full tests with `npm test`
* [ ] Updated inline-comment documentation
* [ ] Lint fixed
* [ ] Squash and rebased
* [ ] Sanity check the final build