### PR TITLE
Changed to using scripts for polykeyWorker.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   "pkg": {
     "assets": [
       "node_modules/leveldown/**/*",
-      "node_modules/utp-native/**/*",
-      "dist/lib/workers/worker.js"
-    ]
+      "node_modules/utp-native/**/*"
+    ],
+    "scripts": "dist/lib/workers/worker.js"
   },
   "scripts": {
     "build": "tsc -p ./tsconfig.build.json",

--- a/src/bin/typescript-demo-lib.ts
+++ b/src/bin/typescript-demo-lib.ts
@@ -7,6 +7,7 @@ import { v4 as uuidv4 } from 'uuid';
 import testWorkers from '../lib/workers/test-workers';
 import testLevel from '../lib/test-level';
 import testUtpNative from '../lib/test-utp-native';
+import * as os from 'os';
 
 async function main(argv = process.argv): Promise<number> {
   // Print out command-line arguments
@@ -28,7 +29,7 @@ async function main(argv = process.argv): Promise<number> {
   process.stdout.write(nums.num1 + ' + ' + nums.num2 + ' = ' + sum + '\n');
 
   // Testing native modules
-  const dir = argv[2] ?? '/tmp';
+  const dir = argv[2] ?? os.tmpdir();
   await testLevel(dir);
   await testWorkers();
   await testUtpNative();


### PR DESCRIPTION
### Description

According to @tegefaulkes this is the correct way of setting `polykeyWorker.js`. I've made the change here. Can you check if windows/linux builds work? If so, merge this PR.