### PR TITLE
Feature 22.05

### DIFF
--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,4 +1,4 @@
 import (
-  let rev = "a5774e76bb8c3145eac524be62375c937143b80c"; in
+  let rev = "ce6aa13369b667ac2542593170993504932eb836"; in
   builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz"
 )

--- a/release.nix
+++ b/release.nix
@@ -72,7 +72,10 @@ in
     docker = dockerTools.buildImage {
       name = application.name;
       contents = [ application ];
+      # This ensures symlinks to directories are preserved in the image
       keepContentsDirlinks = true;
+      # This adds a correct timestamp, however breaks binary reproducibility
+      created = "now";
       extraCommands = ''
         mkdir -m 1777 tmp
       '';


### PR DESCRIPTION
### Description

Upgrades to 22.05 revision ce6aa13369b667ac2542593170993504932eb836 and adds the `created = "now";`.

### Issues Fixed

* Related https://github.com/MatrixAI/js-polykey/pull/396

### Tasks

- [x] 1. Changed `pkgs.nix` to use the 22.05 revision as are using on our OS
- [x] 2. Added `created = "now";` that introduces proper timestamps on our docker images, but binary reproducibility (content hashes) will change, input hashing is preserved 

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
